### PR TITLE
fix(ball): constructor mismatch resolution + cleanup misleading indentation +add doc +add logs

### DIFF
--- a/include/Ball.hpp
+++ b/include/Ball.hpp
@@ -1,23 +1,89 @@
+/**
+ * @file Ball.hpp
+ * @brief Header file for the Ball class, representing the ball in a Pong game.
+ * This class handles the ball's position, movement, and collision logic.
+ * @author Oussama Amara
+ - @date 2025-07-27
+ */
 #pragma once
 #include <SFML/Graphics.hpp>
 
+/**
+ * @class Ball
+ * @brief Represents the ball in a Pong game, handling position, movement, and collision logic.
+ */
 class Ball {
 private:
+    /** @brief Current position of the ball in 2D space. */
     sf::Vector2f m_Position;
+
+    /** @brief Graphical shape used to render the ball (a rectangle). */
     sf::RectangleShape m_Shape;
+
+    /** @brief Movement speed of the ball in pixels per second. */
     float m_Speed = 1000.0f;
+
+    /** @brief Horizontal direction multiplier (-1.0 to 1.0). */
     float m_DirectionX = 0.2f;
+
+    /** @brief Vertical direction multiplier (-1.0 to 1.0). */
     float m_DirectionY = 0.2f;
 
 public:
+    /**
+     * @brief Constructor that initializes the ball at a given starting position.
+     * @param startX Initial x-coordinate.
+     * @param startY Initial y-coordinate.
+     */
     Ball(float startX, float startY);
+
+    /**
+     * @brief Retrieves the current bounding rectangle of the ball.
+     * @return FloatRect representing the ball's position and size.
+     */
     sf::FloatRect getPosition() const;
+
+    /**
+     * @brief Provides read-only access to the ball's graphical shape.
+     * @return Reference to the internal RectangleShape.
+     */
     const sf::RectangleShape& getShape() const;
+
+    /**
+     * @brief Returns the global bounds of the ball for collision detection.
+     * @return FloatRect containing position and dimensions in global coordinates.
+     */
     sf::FloatRect getGlobalBounds() const;
+
+    /**
+     * @brief Returns the current horizontal velocity of the ball.
+     * @return Velocity along the X-axis.
+     */
     float getXVelocity() const;
+
+    /**
+     * @brief Reverses the horizontal direction when hitting left or right walls.
+     */
     void reboundSides();
+
+    /**
+     * @brief Reverses the vertical direction when hitting the bat or top of the screen in single-player mode.
+     */
     void reboundBatOrTop();
+
+    /**
+     * @brief Reverses vertical direction when hitting bat or top edge in multiplayer mode.
+     */
     void reboundBatOrTopMultiplayer();
+
+    /**
+     * @brief Handles logic when the ball hits the bottom of the screen.
+     */
     void reboundBottom();
+
+    /**
+     * @brief Updates the ball's position based on its velocity and elapsed time.
+     * @param dt Time delta since last update.
+     */
     void update(sf::Time dt);
 };

--- a/include/Ball.hpp
+++ b/include/Ball.hpp
@@ -17,6 +17,9 @@ private:
     /** @brief Current position of the ball in 2D space. */
     sf::Vector2f m_Position;
 
+    /** @brief Resolution of the game window, used for positioning and movement calculations. */
+    sf::Vector2f m_Resolution; 
+
     /** @brief Graphical shape used to render the ball (a rectangle). */
     sf::RectangleShape m_Shape;
 
@@ -29,13 +32,15 @@ private:
     /** @brief Vertical direction multiplier (-1.0 to 1.0). */
     float m_DirectionY = 0.2f;
 
+
 public:
     /**
      * @brief Constructor that initializes the ball at a given starting position.
      * @param startX Initial x-coordinate.
      * @param startY Initial y-coordinate.
+     * @param resolution Resolution of the game window, used for positioning and movement calculations.
      */
-    Ball(float startX, float startY);
+    Ball(float startX, float startY, sf::Vector2f resolution);
 
     /**
      * @brief Retrieves the current bounding rectangle of the ball.

--- a/include/Bat.hpp
+++ b/include/Bat.hpp
@@ -1,22 +1,84 @@
+/**
+ * @file Bat.hpp
+ * @brief Header file for the Bat class, representing the player's paddle in a Pong game.
+ * This class handles movement, position tracking, and graphical representation of the paddle.
+ * @author Oussama Amara
+ * @date 2025-07-27
+ */
+
 #pragma once
 #include <SFML/Graphics.hpp>
 
+/**
+ * @class Bat
+ * @brief Represents a paddle controlled by the player, with logic for motion and rendering.
+ */
 class Bat {
 private:
+    /** @brief Current position of the bat in 2D space. */
     sf::Vector2f m_Position;
+
+    /** @brief Graphical shape used to render the bat (a rectangle). */
     sf::RectangleShape m_Shape;
+
+    /** @brief Movement speed of the bat in pixels per second. */
     float m_Speed = 1000.0f;
+
+    /** @brief Indicates whether the bat is currently moving right. */
     bool m_MovingRight = false;
+
+    /** @brief Indicates whether the bat is currently moving left. */
     bool m_MovingLeft = false;
 
 public:
+    /**
+     * @brief Constructs a bat at the given starting coordinates.
+     * @param startX Initial x-coordinate.
+     * @param startY Initial y-coordinate.
+     */
     Bat(float startX, float startY);
+
+    /**
+     * @brief Retrieves the current bounding rectangle of the bat.
+     * @return FloatRect representing the bat's position and size.
+     */
     sf::FloatRect getPosition() const;
+
+    /**
+     * @brief Provides read-only access to the bat's graphical shape.
+     * @return Reference to the internal RectangleShape.
+     */
     const sf::RectangleShape& getShape() const;
+
+    /**
+     * @brief Returns the global bounds of the bat for collision detection.
+     * @return FloatRect containing position and dimensions in global coordinates.
+     */
     sf::FloatRect getGlobalBounds() const;
+
+    /**
+     * @brief Begins leftward movement.
+     */
     void moveLeft();
+
+    /**
+     * @brief Begins rightward movement.
+     */
     void moveRight();
+
+    /**
+     * @brief Stops leftward movement.
+     */
     void stopLeft();
+
+    /**
+     * @brief Stops rightward movement.
+     */
     void stopRight();
+
+    /**
+     * @brief Updates the bat's position based on movement flags and elapsed time.
+     * @param dt Time delta since the last update.
+     */
     void update(sf::Time dt);
 };

--- a/include/Logger.hpp
+++ b/include/Logger.hpp
@@ -1,0 +1,47 @@
+/**
+ * @file Logger.hpp
+ * @brief Minimal logging utility to write debug and error information to a log file.
+ * @author Oussama Amara
+ * @date 2025-07-27
+ */
+
+#pragma once
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <ctime>
+
+class Logger {
+public:
+    Logger(const std::string& filename = "game.log") {
+        logFile.open(filename, std::ios::app);
+    }
+
+    ~Logger() {
+        if (logFile.is_open())
+            logFile.close();
+    }
+
+    void info(const std::string& message) {
+        log("[INFO] " + message);
+    }
+
+    void error(const std::string& message) {
+        log("[ERROR] " + message);
+    }
+
+private:
+    std::ofstream logFile;
+
+    void log(const std::string& entry) {
+        std::time_t now = std::time(nullptr);
+        char buf[64];
+        std::strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", std::localtime(&now));
+
+        std::string finalEntry = "[" + std::string(buf) + "] " + entry;
+        if (logFile.is_open())
+            logFile << finalEntry << std::endl;
+
+        std::cout << finalEntry << std::endl;
+    }
+};

--- a/src/Ball.cpp
+++ b/src/Ball.cpp
@@ -1,5 +1,17 @@
+/**
+ * @file Ball.cpp
+ * @brief Implementation of the Ball class, representing the ball in a Pong game.
+ * This class handles the ball's position, movement, and collision logic.
+ * @author Oussama Amara
+ * @date 2025-07-27
+ */
 #include "Ball.hpp"
 
+/**
+ * @brief Constructs a ball at the specified position.
+ * @param startX X-coordinate for the ball's initial position.
+ * @param startY Y-coordinate for the ball's initial position.
+ */
 Ball::Ball(float startX, float startY)
     : m_Position(startX, startY)
 {
@@ -7,42 +19,74 @@ Ball::Ball(float startX, float startY)
     m_Shape.setPosition(m_Position);
 }
 
+/**
+ * @brief Retrieves the global bounding rectangle of the ball.
+ * @return A FloatRect representing the ball's bounds in global coordinates.
+ */
 sf::FloatRect Ball::getGlobalBounds() const {
     return m_Shape.getGlobalBounds();
 }
 
+/**
+ * @brief Retrieves the current position rectangle of the ball.
+ * @return A FloatRect representing the ball's position and dimensions.
+ */
 sf::FloatRect Ball::getPosition() const {
     return m_Shape.getGlobalBounds();
 }
 
+/**
+ * @brief Provides access to the ball's shape for rendering.
+ * @return A const reference to the RectangleShape.
+ */
 const sf::RectangleShape& Ball::getShape() const {
     return m_Shape;
 }
 
+/**
+ * @brief Returns the horizontal velocity of the ball.
+ * @return The direction multiplier for movement along the X-axis.
+ */
 float Ball::getXVelocity() const {
     return m_DirectionX;
 }
 
+/**
+ * @brief Reverses the horizontal direction to simulate bouncing off side walls.
+ */
 void Ball::reboundSides() {
     m_DirectionX = -m_DirectionX;
 }
 
+/**
+ * @brief Reverses the vertical direction to simulate bounce off top or paddle in single-player mode.
+ */
 void Ball::reboundBatOrTop() {
     m_DirectionY = -m_DirectionY;
 }
 
+/**
+ * @brief Resets position and reverses vertical direction when the ball hits the bottom wall.
+ */
 void Ball::reboundBottom() {
     m_Position = {500.f, 100.f};
     m_DirectionY = -m_DirectionY;
     m_Shape.setPosition(m_Position);
 }
 
+/**
+ * @brief Resets position and reverses direction for multiplayer-specific collision logic.
+ */
 void Ball::reboundBatOrTopMultiplayer() {
     m_Position = {500.f, 100.f};
     m_DirectionY = -m_DirectionY;
     m_Shape.setPosition(m_Position);
 }
 
+/**
+ * @brief Updates ball position based on velocity and elapsed time.
+ * @param dt Time elapsed since last frame.
+ */
 void Ball::update(sf::Time dt) {
     m_Position.x += m_DirectionX * m_Speed * dt.asSeconds();
     m_Position.y += m_DirectionY * m_Speed * dt.asSeconds();

--- a/src/Ball.cpp
+++ b/src/Ball.cpp
@@ -5,23 +5,23 @@
  * @author Oussama Amara
  * @date 2025-07-27
  */
+
 #include "Ball.hpp"
+#include "Logger.hpp"
 
 /**
  * @brief Constructs a ball at the specified position.
- * @param startX X-coordinate for the ball's initial position.
- * @param startY Y-coordinate for the ball's initial position.
  */
 Ball::Ball(float startX, float startY)
     : m_Position(startX, startY)
 {
     m_Shape.setSize(sf::Vector2f(10.f, 10.f));
     m_Shape.setPosition(m_Position);
+    Logger().info("Ball created at position (" + std::to_string(startX) + ", " + std::to_string(startY) + ")");
 }
 
 /**
  * @brief Retrieves the global bounding rectangle of the ball.
- * @return A FloatRect representing the ball's bounds in global coordinates.
  */
 sf::FloatRect Ball::getGlobalBounds() const {
     return m_Shape.getGlobalBounds();
@@ -29,7 +29,6 @@ sf::FloatRect Ball::getGlobalBounds() const {
 
 /**
  * @brief Retrieves the current position rectangle of the ball.
- * @return A FloatRect representing the ball's position and dimensions.
  */
 sf::FloatRect Ball::getPosition() const {
     return m_Shape.getGlobalBounds();
@@ -37,7 +36,6 @@ sf::FloatRect Ball::getPosition() const {
 
 /**
  * @brief Provides access to the ball's shape for rendering.
- * @return A const reference to the RectangleShape.
  */
 const sf::RectangleShape& Ball::getShape() const {
     return m_Shape;
@@ -45,50 +43,53 @@ const sf::RectangleShape& Ball::getShape() const {
 
 /**
  * @brief Returns the horizontal velocity of the ball.
- * @return The direction multiplier for movement along the X-axis.
  */
 float Ball::getXVelocity() const {
     return m_DirectionX;
 }
 
 /**
- * @brief Reverses the horizontal direction to simulate bouncing off side walls.
+ * @brief Reverses horizontal direction to simulate bounce off side walls.
  */
 void Ball::reboundSides() {
     m_DirectionX = -m_DirectionX;
+    Logger().info("Ball rebounded off side wall. DirectionX is now " + std::to_string(m_DirectionX));
 }
 
 /**
- * @brief Reverses the vertical direction to simulate bounce off top or paddle in single-player mode.
+ * @brief Reverses vertical direction when hitting bat or top edge.
  */
 void Ball::reboundBatOrTop() {
     m_DirectionY = -m_DirectionY;
+    Logger().info("Ball rebounded off bat or top. DirectionY is now " + std::to_string(m_DirectionY));
 }
 
 /**
- * @brief Resets position and reverses vertical direction when the ball hits the bottom wall.
+ * @brief Handles ball rebound on bottom hit — resets position.
  */
 void Ball::reboundBottom() {
     m_Position = {500.f, 100.f};
     m_DirectionY = -m_DirectionY;
     m_Shape.setPosition(m_Position);
+    Logger().info("Ball hit bottom. Position reset to (500, 100). DirectionY is now " + std::to_string(m_DirectionY));
 }
 
 /**
- * @brief Resets position and reverses direction for multiplayer-specific collision logic.
+ * @brief Multiplayer-specific rebound logic when hitting top edge or bat.
  */
 void Ball::reboundBatOrTopMultiplayer() {
     m_Position = {500.f, 100.f};
     m_DirectionY = -m_DirectionY;
     m_Shape.setPosition(m_Position);
+    Logger().info("Multiplayer: Ball rebounded off bat or top. Reset position to (500, 100). DirectionY is now " + std::to_string(m_DirectionY));
 }
 
 /**
- * @brief Updates ball position based on velocity and elapsed time.
- * @param dt Time elapsed since last frame.
+ * @brief Updates ball position based on velocity and delta time.
  */
 void Ball::update(sf::Time dt) {
     m_Position.x += m_DirectionX * m_Speed * dt.asSeconds();
     m_Position.y += m_DirectionY * m_Speed * dt.asSeconds();
     m_Shape.setPosition(m_Position);
+    Logger().info("Ball updated position to (" + std::to_string(m_Position.x) + ", " + std::to_string(m_Position.y) + ")");
 }

--- a/src/Ball.cpp
+++ b/src/Ball.cpp
@@ -12,13 +12,14 @@
 /**
  * @brief Constructs a ball at the specified position.
  */
-Ball::Ball(float startX, float startY)
-    : m_Position(startX, startY)
+Ball::Ball(float startX, float startY, sf::Vector2f resolution)
+    : m_Position(startX, startY), m_Resolution(resolution)
 {
     m_Shape.setSize(sf::Vector2f(10.f, 10.f));
     m_Shape.setPosition(m_Position);
     Logger().info("Ball created at position (" + std::to_string(startX) + ", " + std::to_string(startY) + ")");
 }
+
 
 /**
  * @brief Retrieves the global bounding rectangle of the ball.
@@ -68,20 +69,20 @@ void Ball::reboundBatOrTop() {
  * @brief Handles ball rebound on bottom hit — resets position.
  */
 void Ball::reboundBottom() {
-    m_Position = {500.f, 100.f};
+    m_Position = {m_Resolution.x / 2.f, m_Resolution.y / 2.f};
     m_DirectionY = -m_DirectionY;
     m_Shape.setPosition(m_Position);
-    Logger().info("Ball hit bottom. Position reset to (500, 100). DirectionY is now " + std::to_string(m_DirectionY));
+    Logger().info("Ball hit bottom. Position reset to (" + std::to_string(m_Position.x) + ", " + std::to_string(m_Position.y) + "). DirectionY is now " + std::to_string(m_DirectionY));
 }
 
 /**
  * @brief Multiplayer-specific rebound logic when hitting top edge or bat.
  */
 void Ball::reboundBatOrTopMultiplayer() {
-    m_Position = {500.f, 100.f};
+    m_Position = {m_Resolution.x / 2.f, m_Resolution.y / 2.f};
     m_DirectionY = -m_DirectionY;
     m_Shape.setPosition(m_Position);
-    Logger().info("Multiplayer: Ball rebounded off bat or top. Reset position to (500, 100). DirectionY is now " + std::to_string(m_DirectionY));
+    Logger().info("Multiplayer: Ball rebounded. Reset to (" + std::to_string(m_Position.x) + ", " + std::to_string(m_Position.y) + "). DirectionY is now " + std::to_string(m_DirectionY));
 }
 
 /**

--- a/src/Bat.cpp
+++ b/src/Bat.cpp
@@ -1,5 +1,17 @@
+/**
+ * @file Bat.cpp
+ * @brief Implementation of the Bat class, representing the player's paddle in a Pong game.
+ * This class handles the bat's position, movement, and rendering.
+ * @author Oussama Amara
+ *  @date 2025-07-27
+ */
 #include "Bat.hpp"
 
+/**
+ * @brief Constructs a bat at the specified starting coordinates.
+ * @param startX X-coordinate of the bat's initial position.
+ * @param startY Y-coordinate of the bat's initial position.
+ */
 Bat::Bat(float startX, float startY)
     : m_Position(startX, startY)
 {
@@ -7,34 +19,62 @@ Bat::Bat(float startX, float startY)
     m_Shape.setPosition(m_Position);
 }
 
+/**
+ * @brief Retrieves the current bounding rectangle of the bat.
+ * @return FloatRect representing the bat's position and dimensions.
+ */
 sf::FloatRect Bat::getPosition() const {
     return m_Shape.getGlobalBounds();
 }
 
+/**
+ * @brief Retrieves the global bounding box of the bat for collision detection.
+ * @return FloatRect containing global position and size.
+ */
 sf::FloatRect Bat::getGlobalBounds() const {
     return m_Shape.getGlobalBounds();
 }
 
+/**
+ * @brief Provides access to the graphical shape of the bat for rendering.
+ * @return Const reference to the RectangleShape.
+ */
 const sf::RectangleShape& Bat::getShape() const {
     return m_Shape;
 }
 
+/**
+ * @brief Initiates movement to the left by setting the flag.
+ */
 void Bat::moveLeft() {
     m_MovingLeft = true;
 }
 
+/**
+ * @brief Initiates movement to the right by setting the flag.
+ */
 void Bat::moveRight() {
     m_MovingRight = true;
 }
 
+/**
+ * @brief Stops leftward movement by resetting the flag.
+ */
 void Bat::stopLeft() {
     m_MovingLeft = false;
 }
 
+/**
+ * @brief Stops rightward movement by resetting the flag.
+ */
 void Bat::stopRight() {
     m_MovingRight = false;
 }
 
+/**
+ * @brief Updates the bat's position based on movement flags and elapsed time.
+ * @param dt Time elapsed since last frame.
+ */
 void Bat::update(sf::Time dt) {
     if (m_MovingLeft)
         m_Position.x -= m_Speed * dt.asSeconds();

--- a/src/Bat.cpp
+++ b/src/Bat.cpp
@@ -3,83 +3,99 @@
  * @brief Implementation of the Bat class, representing the player's paddle in a Pong game.
  * This class handles the bat's position, movement, and rendering.
  * @author Oussama Amara
- *  @date 2025-07-27
+ * @date 2025-07-27
  */
+
 #include "Bat.hpp"
+#include "Logger.hpp"
 
 /**
- * @brief Constructs a bat at the specified starting coordinates.
- * @param startX X-coordinate of the bat's initial position.
- * @param startY Y-coordinate of the bat's initial position.
+ * @brief Constructs a bat at the given coordinates.
  */
 Bat::Bat(float startX, float startY)
     : m_Position(startX, startY)
 {
     m_Shape.setSize(sf::Vector2f(50.f, 5.f));
     m_Shape.setPosition(m_Position);
+    Logger().info("Bat created at position (" + std::to_string(startX) + ", " + std::to_string(startY) + ")");
 }
 
 /**
- * @brief Retrieves the current bounding rectangle of the bat.
- * @return FloatRect representing the bat's position and dimensions.
+ * @brief Retrieves the bat's bounding rectangle.
  */
 sf::FloatRect Bat::getPosition() const {
     return m_Shape.getGlobalBounds();
 }
 
 /**
- * @brief Retrieves the global bounding box of the bat for collision detection.
- * @return FloatRect containing global position and size.
+ * @brief Gets global bounds for collision detection.
  */
 sf::FloatRect Bat::getGlobalBounds() const {
     return m_Shape.getGlobalBounds();
 }
 
 /**
- * @brief Provides access to the graphical shape of the bat for rendering.
- * @return Const reference to the RectangleShape.
+ * @brief Accesses bat shape for rendering.
  */
 const sf::RectangleShape& Bat::getShape() const {
     return m_Shape;
 }
 
 /**
- * @brief Initiates movement to the left by setting the flag.
+ * @brief Begins movement to the left.
  */
 void Bat::moveLeft() {
     m_MovingLeft = true;
+    Logger().info("Bat movement: left initiated");
 }
 
 /**
- * @brief Initiates movement to the right by setting the flag.
+ * @brief Begins movement to the right.
  */
 void Bat::moveRight() {
     m_MovingRight = true;
+    Logger().info("Bat movement: right initiated");
 }
 
 /**
- * @brief Stops leftward movement by resetting the flag.
+ * @brief Stops leftward movement.
  */
 void Bat::stopLeft() {
+    if (m_MovingLeft) {
+        Logger().info("Bat movement: left stopped");
+    }
     m_MovingLeft = false;
 }
 
 /**
- * @brief Stops rightward movement by resetting the flag.
+ * @brief Stops rightward movement.
  */
 void Bat::stopRight() {
+    if (m_MovingRight) {
+        Logger().info("Bat movement: right stopped");
+    }
     m_MovingRight = false;
 }
 
 /**
- * @brief Updates the bat's position based on movement flags and elapsed time.
- * @param dt Time elapsed since last frame.
+ * @brief Updates bat position based on movement flags.
  */
 void Bat::update(sf::Time dt) {
-    if (m_MovingLeft)
+    bool updated = false;
+
+    if (m_MovingLeft) {
         m_Position.x -= m_Speed * dt.asSeconds();
-    if (m_MovingRight)
+        updated = true;
+    }
+
+    if (m_MovingRight) {
         m_Position.x += m_Speed * dt.asSeconds();
+        updated = true;
+    }
 
     m_Shape.setPosition(m_Position);
+
+    if (updated) {
+        Logger().info("Bat updated position to (" + std::to_string(m_Position.x) + ", " + std::to_string(m_Position.y) + ")");
+    }
 }

--- a/src/Pong.cpp
+++ b/src/Pong.cpp
@@ -46,7 +46,7 @@ int main() {
     // Create bats and ball
     Bat bat_1(resolution.x / 2, resolution.y - 80); // Player 1 at bottom
     Bat bat_2(resolution.x / 2, 20);               // Player 2 at top
-    Ball ball(resolution.x / 2, 0);
+    Ball ball(resolution.x / 2.f, 0.f,resolution);
 
     // HUD setup (SFML 3.0.0 compliant)
     sf::Font font;
@@ -172,6 +172,8 @@ int main() {
                 log.info("Ball hit bottom wall — Player 1 lives left: " + std::to_string(lives_1));
                 if (lives_1 < 1) {
                     log.info("Player 1 game over — returning to MENU");
+                    ball = Ball(resolution.x / 2.f, resolution.y / 2.f,resolution); // Reset to center
+                    Time_elapsed = 0; // Prevent immediate scoring
                     state = State::MENU;
                     score_1 = 0;
                     lives_1 = 3;
@@ -261,6 +263,8 @@ int main() {
                 lives_1--;
                 score_2++;
                 if (lives_1 < 1) {
+                     ball = Ball(resolution.x / 2.f, resolution.y / 2.f,resolution); // Reset to center
+                    Time_elapsed = 0; // Prevent immediate scoring
                     state = State::MENU;
                     score_1 = score_2 = 0;
                     lives_1 = lives_2 = 3;

--- a/src/Pong.cpp
+++ b/src/Pong.cpp
@@ -14,12 +14,17 @@
 #include <cstdlib>
 #include <optional>
 #include <iostream>
+#include "Logger.hpp"
 
 int main() {
+    Logger log; // Initialize logger
+    log.info("Game starting...");
+
     // The game will always be in one of three states
     enum class State { MENU, SINGLEPLAYER, MULTIPLAYER };
     // Start with the MENU state
     State state = State::MENU;
+    log.info("Initial game state: MENU");
 
     // Create a video mode object based on desktop resolution
     sf::Vector2f resolution;
@@ -29,7 +34,7 @@ int main() {
     // Create and open a window for the game
     sf::RenderWindow window;
     window.create(sf::VideoMode({static_cast<unsigned int>(resolution.x), static_cast<unsigned int>(resolution.y)}), "Pong");
-
+    log.info("Render window created with resolution: " + std::to_string((int)resolution.x) + "x" + std::to_string((int)resolution.y));
     // Player 1
     int score_1 = 0;
     int lives_1 = 3;
@@ -47,9 +52,10 @@ int main() {
     sf::Font font;
     if (!font.openFromFile("fonts/DS-DIGI.TTF")) {
         std::cerr << "Failed to load font: DS-DIGI.TTF" << std::endl;
+        log.error("Failed to load font");
         return -1;
     }
-
+    log.info("Font loaded successfully");
     sf::Text hud_1(font, "Score: 0", 25);
     sf::Text hud_2(font, "Lives: 3", 25);
 
@@ -78,34 +84,44 @@ int main() {
         **********************************
         */
         while (auto event = window.pollEvent()) {
-            if (event->is<sf::Event::Closed>())
+            if (event->is<sf::Event::Closed>()){
+                log.info("Window close event triggered");
                 window.close();
+            }
 
     if (event->is<sf::Event::KeyPressed>()) {
         const auto* keyEvent = event->getIf<sf::Event::KeyPressed>();
         if (keyEvent) {
             auto key = keyEvent->scancode;
-
             if (state == State::MENU) {
-                if (key == sf::Keyboard::Scancode::Num1)
+                if (key == sf::Keyboard::Scancode::Num1){
                     state = State::SINGLEPLAYER; // change mode to single player
-                else if (key == sf::Keyboard::Scancode::Num2)
+                    log.info("Switched to SINGLEPLAYER mode");
+                }
+                else if (key == sf::Keyboard::Scancode::Num2){
                     state = State::MULTIPLAYER; // change mode to multiplayer
+                    log.info("Switched to MULTIPLAYER mode");
+                }
             }
 
-            if (key == sf::Keyboard::Scancode::M)
+            if (key == sf::Keyboard::Scancode::M){
                 state = State::MENU; // back to menu
+                log.info("Returned to MENU");
+            }
         }
 }
 
         }
 
         // Handle the player quitting
-        if (sf::Keyboard::isKeyPressed(sf::Keyboard::Key::Escape))
+        if (sf::Keyboard::isKeyPressed(sf::Keyboard::Key::Escape)) {
+            log.info("Escape pressed — exiting");
             window.close();
+        }
 
         /******* MENU STATE *******/
         if (state == State::MENU) {
+            log.info("Rendering menu");
             window.clear();
             window.draw(GameMode); // draw menu to the screen
             window.display();      // Required to display rendered content
@@ -118,6 +134,7 @@ int main() {
 
         /******* SINGLE PLAYER MODE *******/
         if (state == State::SINGLEPLAYER) {
+            log.info("Singleplayer tick");
             auto batBounds = bat_1.getGlobalBounds();
             auto batPos = batBounds.position;
             auto batSize = batBounds.size;
@@ -152,7 +169,9 @@ int main() {
             if (ballPos.y > window.getSize().y) {
                 ball.reboundBottom();
                 lives_1--;
+                log.info("Ball hit bottom wall — Player 1 lives left: " + std::to_string(lives_1));
                 if (lives_1 < 1) {
+                    log.info("Player 1 game over — returning to MENU");
                     state = State::MENU;
                     score_1 = 0;
                     lives_1 = 3;
@@ -162,6 +181,7 @@ int main() {
             if (ballPos.y < 0) {
                 ball.reboundBatOrTop();
                 if (Time_elapsed > 1)
+                    log.info("Player 1 scored — Score: " + std::to_string(score_1));
                     score_1++;
             }
 
@@ -180,6 +200,7 @@ int main() {
 
         /******* MULTIPLAYER MODE *******/
         if (state == State::MULTIPLAYER) {
+            log.info("Multiplayer tick");
             auto bat1Bounds = bat_1.getGlobalBounds();
             auto bat1Pos = bat1Bounds.position;
             auto bat1Size = bat1Bounds.size;
@@ -235,6 +256,7 @@ int main() {
             auto ballSize = ballBounds.size;
 
             if (ballPos.y > window.getSize().y) {
+                log.info("Player 2 scored — Player 1 lives: " + std::to_string(lives_1));
                 ball.reboundBottom();
                 lives_1--;
                 score_2++;
@@ -246,6 +268,7 @@ int main() {
             }
 
             if (ballPos.y < 0) {
+                log.info("Player 1 scored — Player 2 lives: " + std::to_string(lives_2));
                 ball.reboundBatOrTopMultiplayer();
                 score_1++;
                 lives_2--;
@@ -275,6 +298,6 @@ int main() {
         }
     }
 
-
+    log.info("Game shutdown");
     return 0;
 }

--- a/src/Pong.cpp
+++ b/src/Pong.cpp
@@ -1,3 +1,11 @@
+/**
+ * @file Pong.cpp
+ * @brief Main entry point for the Pong game using SFML.
+ * Handles game loop, rendering, input management, and transitions between menu, single-player, and multiplayer modes.
+ * @author Oussama Amara
+ * @date 2025-07-27
+ */
+
 #include "Bat.hpp"
 #include "Ball.hpp"
 #include <SFML/Graphics.hpp>


### PR DESCRIPTION
This update addresses a compilation error related to Ball constructor usage in Pong.cpp. The constructor was called with two arguments, whereas the defined constructor expects three (float, float, sf::Vector2f). Additionally, the patch cleans up misleading indentation in a conditional block and enhances code clarity.
Add code  docum
Add log  to debug
